### PR TITLE
Updated blip to be more visible

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -81,11 +81,11 @@ local function UpdateBlip()
 
             HotdogBlip = AddBlipForCoord(coords.x, coords.y, coords.z)
 
-            SetBlipSprite(HotdogBlip, 93)
+            SetBlipSprite(HotdogBlip, 542)
             SetBlipDisplay(HotdogBlip, 4)
             SetBlipScale(HotdogBlip, 0.6)
             SetBlipAsShortRange(HotdogBlip, true)
-            SetBlipColour(HotdogBlip, 0)
+            SetBlipColour(HotdogBlip, 17)
             BeginTextCommandSetBlipName("STRING")
             AddTextComponentSubstringPlayerName(Lang:t("info.blip_name"))
             EndTextCommandSetBlipName(HotdogBlip)


### PR DESCRIPTION
**Describe Pull request**
Updated the hot dog job blip to be an orange H to be more visible.
![image](https://user-images.githubusercontent.com/96954031/179845654-03bde2e8-51f3-4c3b-a844-d7faaa5a059d.png)



**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
