### PR TITLE
Correct distance for exploit ban

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -34,7 +34,7 @@ RegisterNetEvent('qb-hotdogjob:server:Sell', function(coords, amount, price)
     local pCoords = GetEntityCoords(GetPlayerPed(src))
     local Player = QBCore.Functions.GetPlayer(src)
     if not Player then return end
-    if #(pCoords - coords) > 2 then exports['qb-core']:ExploitBan(src, 'hotdog job') end
+    if #(pCoords - coords) > 4 then exports['qb-core']:ExploitBan(src, 'hotdog job') end
     Player.Functions.AddMoney('cash', tonumber(amount * price), 'hotdog')
 end)
 


### PR DESCRIPTION
The client script allows sales for up to 4 units of distance away, however the exploit ban happens at greater than 2 units. This brings the two in line by increasing the server-side check to 4.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
