### PR TITLE
Fix info.command key in es.lua

### DIFF
--- a/locales/es.lua
+++ b/locales/es.lua
@@ -17,7 +17,7 @@ local Translations = {
         made_luck_hotdog = 'Has hecho %{valor} x %{valor2} perritos calientes',
     },
     info = {
-        comando = "Borrar puesto (sólo para administradores)",
+        command = "Borrar puesto (sólo para administradores)",
         blip_name = 'Puesto de perritos calientes',
         start_working = '[E] Empezar a trabajar',
         start_work = 'Empezar a trabajar',


### PR DESCRIPTION
**Describe Pull request**
info.command key is translated when it shouldn't.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
